### PR TITLE
Fix exit after `statResult.ok`

### DIFF
--- a/core/mod.ts
+++ b/core/mod.ts
@@ -29,7 +29,7 @@ export const defineTask = (actions: Action[]) => {
     for (const { stat, run } of actions) {
       const statResult = await stat();
 
-      if (statResult.ok) return;
+      if (statResult.ok) continue;
 
       try {
         await run();


### PR DESCRIPTION
`statResult.ok === true` なactionが存在した場合、そこでexecuteRun自体がexitして以降のactionが無視されるので、deploy済みのaction以降に新しくactionを追記した場合、その記述は無視されてしまいます。

`return` でexitしているところを `continue` に変更しました。